### PR TITLE
Make year a string

### DIFF
--- a/ncigrafana/DBcommon.py
+++ b/ncigrafana/DBcommon.py
@@ -97,7 +97,11 @@ def archive(filepath,archive_dir='archive'):
             print("Error removing ",filepath)
 
 def datetoyearquarter(date):
-    year = date.year
+    """Return NCI style year, quarter from date"""
+
+    # Year needs to be a string as SQL field is string
+    year = str(date.year)
+
     # Convert month into year and quarter
     quarter = 'q{}'.format(int(((date.month) - 1) / 3) + 1)
     return year, quarter

--- a/ncigrafana/DBcommon.py
+++ b/ncigrafana/DBcommon.py
@@ -99,8 +99,7 @@ def archive(filepath,archive_dir='archive'):
 def datetoyearquarter(date):
     """Return NCI style year, quarter from date"""
 
-    # Year needs to be a string as SQL field is string
-    year = str(date.year)
+    year = date.year
 
     # Convert month into year and quarter
     quarter = 'q{}'.format(int(((date.month) - 1) / 3) + 1)

--- a/ncigrafana/UsageDataset.py
+++ b/ncigrafana/UsageDataset.py
@@ -84,6 +84,9 @@ class ProjectDataset(object):
         Add a unique quarter
         Return a unique id
         """
+        # Ensure year is a string, to match SQL table type
+        if not isinstance(year, str):
+            year = str(year)
         q = self.db['Quarters'].find_one(year=year,quarter=quarter)
         if q is None:
             if startdate is None or enddate is None:
@@ -518,9 +521,10 @@ class ProjectDataset(object):
     def getquarter(self):
         """
         Return (year, quarter) for the most recent entry in the DB table Quarters
+        Make sure to cast year to integer as it is stored as a string in the postgres DB
         """
         q = self.db['Quarters'].find_one(order_by=['-year','-quarter'])
-        return q['year'], q['quarter'] 
+        return int(q['year']), q['quarter'] 
 
     def getsystems(self):
         """


### PR DESCRIPTION
Make year a string to be consistent with PG DB data type in Quarter table

From this error:

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedFunction) operator does not exist: text = integer                           
LINE 3: WHERE "Quarters".year = 2020 AND "Quarters".quarter = 'q1'
                              ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.                             
```

At this location:
```
  File "/g/data/hh5/public/apps/miniconda3/envs/cms/stats/lib/python3.7/site-packages/ncigrafana/parse_account_usage_data.py", line 63,
in parse_account_dump_file
    db.addquarter(year, quarter, startdate, enddate)
  File "/g/data/hh5/public/apps/miniconda3/envs/cms/stats/lib/python3.7/site-packages/ncigrafana/UsageDataset.py", line 87, in addquarte
r
    q = self.db['Quarters'].find_one(year=year,quarter=quarter)
```