### PR TITLE
Fix parsing error with storage outputs

### DIFF
--- a/ncigrafana/parse_user_storage_data.py
+++ b/ncigrafana/parse_user_storage_data.py
@@ -69,15 +69,14 @@ def parse_file_report(filename, verbose, db=None, dburl=None):
 
             if parsing_usage:
                 try:
-                    (filesystem,scandate,proj,folder,user,size,filesize,inodes) = line.strip(os.linesep).split() 
+                    (filesystem,scandate,folder,proj,user,size,filesize,inodes) = line.strip(os.linesep).split() 
                 except:
                     if verbose: print('Finished parsing short usage')
                     parsing_usage = False
                     continue
                 db.adduser(user)
-                if verbose: print('Adding ', project, user, system, storagepoint, 
-                                                   str(date), folder, 
-                                                   parse_size(size.upper()), inodes)
+                if verbose: print('Adding ', project, user, system, storagepoint, str(date), folder, 
+                                             parse_size(size.upper(), u='', pre='BKMGTPEZY'), inodes)
                 db.adduserstorage(project, 
                                   user, 
                                   system, 

--- a/test/2020-04-16T08:34:58.w35.gdata.dump
+++ b/test/2020-04-16T08:34:58.w35.gdata.dump
@@ -1,40 +1,40 @@
 %%%%%%%%%%%%%%%%
 Thu Apr 16 08:34:58 AEST 2020
-FILESYSTEM  SCAN DATE   PROJECT  GROUP       USER    SPACE USED  TOTAL SIZE  COUNT                          
-gdata       2020-04-16  w35      ua8         pxp581       1236G       1236G  2873
-gdata       2020-04-16  w35      w35         pxp581       2368M       2157M  112349
-gdata       2020-04-16  w35      w40         saw562        330G        330G  2233
-gdata       2020-04-16  w35      access      saw562       2719M       2658M  30611
-gdata       2020-04-16  w35      ua8         saw562        868K        855K  6
-gdata       2020-04-16  w35      w35         saw562       6526G       6534G  247010
-gdata       2020-04-16  w35      access.dev  saw562       3004K       2197K  421
-gdata       2020-04-16  w35      w35         ccc561       1762G       1762G  128209
-gdata       2020-04-16  w35      sx70        ccc561       28.1M       28.1M  1
-gdata       2020-04-16  w35      v45         aph502        604K        248k  95
-gdata       2020-04-16  w35      w35         aph502       4014M       4013M  150
-gdata       2020-04-16  w35      access      hxw599       14.7M       14.5M  173
-gdata       2020-04-16  w35      w35         hxw599       94.6G       99.4G  129
-gdata       2020-04-16  w35      w35         dei561       2780K       2766K  7
-gdata       2020-04-16  w35      hh5         ccc561        356K        272K  28
-gdata       2020-04-16  w35      w97         ccc561        692K        689K  1
-gdata       2020-04-16  w35      hh5         saw562       5848K       5824K  15
+FILESYSTEM  SCAN DATE   PROJECT    GROUP       USER    SPACE USED  TOTAL SIZE  COUNT                          
+gdata       2020-04-16  ua8        w35         pxp581       1236G       1236G  2873
+gdata       2020-04-16  w35        w35         pxp581       2368M       2157M  112349
+gdata       2020-04-16  w40        w35         saw562        330G        330G  2233
+gdata       2020-04-16  access     w35         saw562       2719M       2658M  30611
+gdata       2020-04-16  ua8        w35         saw562        868K        855K  6
+gdata       2020-04-16  w35        w35         saw562       6526G       6534G  247010
+gdata       2020-04-16  access.dev w35         saw562       3004K       2197K  421
+gdata       2020-04-16  w35        w35         ccc561       1762G       1762G  128209
+gdata       2020-04-16  sx70       w35         ccc561       28.1M       28.1M  1
+gdata       2020-04-16  v45        w35         aph502        604K        248k  95
+gdata       2020-04-16  w35        w35         aph502       4014M       4013M  150
+gdata       2020-04-16  access     w35         hxw599       14.7M       14.5M  173
+gdata       2020-04-16  w35        w35         hxw599       94.6G       99.4G  129
+gdata       2020-04-16  w35        w35         dei561       2780K       2766K  7
+gdata       2020-04-16  hh5        w35         ccc561        356K        272K  28
+gdata       2020-04-16  w97        w35         ccc561        692K        689K  1
+gdata       2020-04-16  hh5        w35         saw562       5848K       5824K  15
 %%%%%%%%%%%%%%%%
 Fri Apr 17 08:34:58 AEST 2020
 FILESYSTEM  SCAN DATE   PROJECT  GROUP       USER    SPACE USED  TOTAL SIZE  COUNT                          
-gdata       2020-04-16  w35      ua8         pxp581       1236G       1236G  2873
-gdata       2020-04-16  w35      w35         pxp581       2368M       2157M  112349
-gdata       2020-04-16  w35      w40         saw562        330G        330G  2233
-gdata       2020-04-16  w35      access      saw562       2719M       2658M  30611
-gdata       2020-04-16  w35      ua8         saw562        868K        855K  6
-gdata       2020-04-16  w35      w35         saw562       6526G       6534G  247010
-gdata       2020-04-16  w35      access.dev  saw562       3004K       2197K  421
-gdata       2020-04-16  w35      w35         ccc561       1762G       1762G  128209
-gdata       2020-04-16  w35      sx70        ccc561       28.1M       28.1M  1
-gdata       2020-04-16  w35      v45         aph502        604K        248k  95
-gdata       2020-04-16  w35      w35         aph502       4014M       4013M  150
-gdata       2020-04-16  w35      access      hxw599       14.7M       14.5M  173
-gdata       2020-04-16  w35      w35         hxw599       94.6G       99.4G  129
-gdata       2020-04-16  w35      w35         dei561       2780K       2766K  7
-gdata       2020-04-16  w35      hh5         ccc561        356K        272K  28
-gdata       2020-04-16  w35      w97         ccc561        692K        689K  1
-gdata       2020-04-16  w35      hh5         saw562       5848K       5824K  15
+gdata       2020-04-17  ua8        w35         pxp581       1236G       1236G  2873
+gdata       2020-04-17  w35        w35         pxp581       2368M       2157M  112349
+gdata       2020-04-17  w40        w35         saw562        330G        330G  2233
+gdata       2020-04-17  access     w35         saw562       2719M       2658M  30611
+gdata       2020-04-17  ua8        w35         saw562        868K        855K  6
+gdata       2020-04-17  w35        w35         saw562       6526G       6534G  247010
+gdata       2020-04-17  access.dev w35         saw562       3004K       2197K  421
+gdata       2020-04-17  w35        w35         ccc561       1762G       1762G  128209
+gdata       2020-04-17  sx70       w35         ccc561       28.1M       28.1M  1
+gdata       2020-04-17  v45        w35         aph502        604K        248k  95
+gdata       2020-04-17  w35        w35         aph502       4014M       4013M  150
+gdata       2020-04-17  access     w35         hxw599       14.7M       14.5M  173
+gdata       2020-04-17  w35        w35         hxw599       94.6G       99.4G  129
+gdata       2020-04-17  w35        w35         dei561       2780K       2766K  7
+gdata       2020-04-17  hh5        w35         ccc561        356K        272K  28
+gdata       2020-04-17  w97        w35         ccc561        692K        689K  1
+gdata       2020-04-17  hh5        w35         saw562       5848K       5824K  15

--- a/test/2020-04-16T08:34:58.w35.scratch.dump
+++ b/test/2020-04-16T08:34:58.w35.scratch.dump
@@ -1,28 +1,28 @@
 %%%%%%%%%%%%%%%%
 Thu Apr 16 08:34:58 AEST 2020
 FILESYSTEM  SCAN DATE   PROJECT  GROUP   USER    SPACE USED  TOTAL SIZE  COUNT
-scratch     2020-04-16  w35      w35     mjl561       76.2G       76.2G  3495
-scratch     2020-04-16  w35      access  saw562       28.0K       21.8K  3
-scratch     2020-04-16  w35      ly62    saw562       6721G       6721G  15
-scratch     2020-04-16  w35      w35     saw562       30.3T       30.3T  1045201
-scratch     2020-04-16  w35      w35     ccc561        610G        612G  77768
-scratch     2020-04-16  w35      public  ccc561        172K        169K  1
-scratch     2020-04-16  w35      w35     pxp581       1810M       1810M  8
-scratch     2020-04-16  w35      w35     dei561       5706M       5656M  47629
-scratch     2020-04-16  w35      v45     aph502        795M        785M  11137
-scratch     2020-04-16  w35      w35     aph502       3424K       3277K  87
-scratch     2020-04-16  w35      w97     aph502          0B          0B  0
+scratch     2020-04-16  w35     w35      mjl561       76.2G       76.2G  3495
+scratch     2020-04-16  access  w35      saw562       28.0K       21.8K  3
+scratch     2020-04-16  ly62    w35      saw562       6721G       6721G  15
+scratch     2020-04-16  w35     w35      saw562       30.3T       30.3T  1045201
+scratch     2020-04-16  w35     w35      ccc561        610G        612G  77768
+scratch     2020-04-16  public  w35      ccc561        172K        169K  1
+scratch     2020-04-16  w35     w35      pxp581       1810M       1810M  8
+scratch     2020-04-16  w35     w35      dei561       5706M       5656M  47629
+scratch     2020-04-16  v45     w35      aph502        795M        785M  11137
+scratch     2020-04-16  w35     w35      aph502       3424K       3277K  87
+scratch     2020-04-16  w97     w35      aph502          0B          0B  0
 %%%%%%%%%%%%%%%%
 Fri Apr 17 08:34:58 AEST 2020
 FILESYSTEM  SCAN DATE   PROJECT  GROUP   USER    SPACE USED  TOTAL SIZE  COUNT
-scratch     2020-04-16  w35      w35     mjl561       76.2G       76.2G  3495
-scratch     2020-04-16  w35      access  saw562       28.0K       21.8K  3
-scratch     2020-04-16  w35      ly62    saw562       6721G       6721G  15
-scratch     2020-04-16  w35      w35     saw562       30.3T       30.3T  1045201
-scratch     2020-04-16  w35      w35     ccc561        610G        612G  77768
-scratch     2020-04-16  w35      public  ccc561        172K        169K  1
-scratch     2020-04-16  w35      w35     pxp581       1810M       1810M  8
-scratch     2020-04-16  w35      w35     dei561       5706M       5656M  47629
-scratch     2020-04-16  w35      v45     aph502        795M        785M  11137
-scratch     2020-04-16  w35      w35     aph502       3424K       3277K  87
-scratch     2020-04-16  w35      w97     aph502          0B          0B  0
+scratch     2020-04-17  w35     w35      mjl561       76.2G       76.2G  3495
+scratch     2020-04-17  access  w35      saw562       28.0K       21.8K  3
+scratch     2020-04-17  ly62    w35      saw562       6721G       6721G  15
+scratch     2020-04-17  w35     w35      saw562       30.3T       30.3T  1045201
+scratch     2020-04-17  w35     w35      ccc561        610G        612G  77768
+scratch     2020-04-17  public  w35      ccc561        172K        169K  1
+scratch     2020-04-17  w35     w35      pxp581       1810M       1810M  8
+scratch     2020-04-17  w35     w35      dei561       5706M       5656M  47629
+scratch     2020-04-17  v45     w35      aph502        795M        785M  11137
+scratch     2020-04-17  w35     w35      aph502       3424K       3277K  87
+scratch     2020-04-17  w97     w35      aph502          0B          0B  0


### PR DESCRIPTION
Fixed error in parsing nci-files-report output. Had folder and project mixed up. Closes #13 